### PR TITLE
Initial add of ingress for using deep links

### DIFF
--- a/helm/atlas-teleport-app/templates/7-ingress.yaml
+++ b/helm/atlas-teleport-app/templates/7-ingress.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.enabled.ingress -}}
+{{- $ns := include "teleport.namespace" . -}}
+{{- $appName := include "teleport.name" . -}}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $appName }}-ingress
+  namespace: {{ $ns }}
+  annotations:
+    kubernetes.io/ingress.class: {{ tpl (.Values.host.csp.ingressClass) . }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    nginx.ingress.kubernetes.io/limit-rps: "50"
+    nginx.ingress.kubernetes.io/rewrite-target: {{ tpl .Values.ingress.rewrite . }}
+spec:
+  rules:
+  - http:
+      paths:
+      - path: {{ .Values.ingress.path }}
+        backend:
+          serviceName: {{ $appName }}-external
+          servicePort: proxyweb
+    host: {{ tpl (.Values.host.csp.domain) . }}
+  tls:
+  - secretName: {{ tpl .Values.proxy.tls.secretName . }}
+    hosts:
+    - {{ tpl (.Values.host.csp.domain) . }}
+{{- end -}}

--- a/helm/atlas-teleport-app/values.yaml
+++ b/helm/atlas-teleport-app/values.yaml
@@ -7,6 +7,7 @@ env: env-4
 host:
   csp:
     domain: "{{ .Values.env }}.test.infoblox.com"
+    ingressClass: nginx
 
 region: us-east-1
 replicas: 1
@@ -17,6 +18,7 @@ serviceInternalName: internal
 enabled:
   # ------------------- begin enabled
     namespace: true            # 1
+    ingress: true              # 2
   # ------------------- end enabled
 
 image:
@@ -169,3 +171,7 @@ github:
     logins:
     - root
     kubernetesGroups: ["system:masters"]
+
+ingress:
+  path: "/api/debug/v2/launch/(.*)/"
+  rewrite: "https://{{ tpl .Values.appDomain . }}:3080/webapi/github/login/web?connector_id=github&redirect_url=https://{{ tpl .Values.appDomain . }}:3080/web/cluster/{{ .Values.env }}/console/node/$1/root"


### PR DESCRIPTION
This ingress is used to start of debugging session via deep links.
The previous approach is to use the path:
```
/api/debug/v1/launch/${OPHID}/
```
The new current approach is to manually change the path to:
```
/api/debug/v2/launch/${OPHID}/
```
The path will be rewritten by ingress to use a deep link and will redirect to the debug session via teleport. Currently the only login as `root` is possible.