### PR TITLE
Functionality to start ssh session with default login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ $(BUILDDIR)/tsh:
 # only tsh is built.
 #
 .PHONY:full
-full: all $(BUILDDIR)/webassets.zip
+full: docker-binaries $(BUILDDIR)/webassets.zip
 ifneq ("$(OS)", "windows")
 	@echo "---> Attaching OSS web assets."
 	cat $(BUILDDIR)/webassets.zip >> $(BUILDDIR)/teleport

--- a/helm/atlas-teleport-app/values.yaml
+++ b/helm/atlas-teleport-app/values.yaml
@@ -174,4 +174,4 @@ github:
 
 ingress:
   path: "/api/debug/v2/launch/(.*)/"
-  rewrite: "https://{{ tpl .Values.appDomain . }}:3080/webapi/github/login/web?connector_id=github&redirect_url=https://{{ tpl .Values.appDomain . }}:3080/web/cluster/{{ .Values.env }}/console/node/$1/root"
+  rewrite: "https://{{ tpl .Values.appDomain . }}:3080/webapi/github/login/web?connector_id=github&redirect_url=https://{{ tpl .Values.appDomain . }}:3080/web/cluster/{{ .Values.env }}/console/node/$1/default"

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -631,3 +631,30 @@ func CheckPasswordLimiter() *limiter.Limiter {
 	}
 	return limiter
 }
+
+const (
+	// DefaultLoginKeyword is login for starting debug session with the highest available permissions
+	DefaultLoginKeyword = "default"
+)
+
+var (
+	// LoginToPriority mapping of available logins to priority
+	LoginToPriority = map[string]int{
+		"root":     1,
+		"dev":      2,
+		"qa":       3,
+		"support":  4,
+		"customer": 5,
+		"user":     6,
+	}
+
+	// PriorityToLogin mapping of priority to available logins
+	PriorityToLogin = map[int]string{
+		1: "root",
+		2: "dev",
+		3: "qa",
+		4: "support",
+		5: "customer",
+		6: "user",
+	}
+)


### PR DESCRIPTION
Default login adds the possibility to login via a deep link without specifying the concrete login but with the `default` login. The specific login, in this case, is the login with the highest permissions from possible logins for the specific GitHub user.

Also changed target in the `Makefile` in order to build binaries with docker.