### PR TITLE
Implementation of multihost support

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -897,6 +897,10 @@ func onMultihost(cf *CLIConf) {
 		return
 	}
 
+	// The interactive session for multihost is not allowed
+	cf.Interactive = false
+	cf.BenchInteractive = false
+
 	for _, host := range cf.HostsList {
 		c := *cf
 		c.UserHost = host


### PR DESCRIPTION
Implementation of multiophid support via new `tsh` command `multihost`.

A list of hosts may be passed as a `multihost` command flag or via an external file (data from the file will be joined with data from the flag).
A list of commands may be passed as a `multihost` command flag or via an external file (data from the file have precedence over data from the flag).