### PR TITLE
Add authorization via S2S token and service user

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -800,7 +800,9 @@ func (s *APIServer) authenticateSSHUserS2S(auth ClientI, w http.ResponseWriter, 
 	if err := httplib.ReadJSON(r, &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	req.Username = p.ByName("user")
+	if p.ByName("user") != "" {
+		req.Username = p.ByName("user")
+	}
 	return auth.AuthenticateSSHUserS2S(req)
 }
 

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -103,6 +103,7 @@ func NewAPIServer(config *APIConfig) http.Handler {
 	srv.GET("/:version/users/:user/web/sessions/:sid", srv.withAuth(srv.getWebSession))
 	srv.DELETE("/:version/users/:user/web/sessions/:sid", srv.withAuth(srv.deleteWebSession))
 	srv.POST("/:version/web/password/token", srv.withRate(srv.withAuth(srv.changePasswordWithToken)))
+	srv.POST("/:version/service/authenticate", srv.withAuth(srv.authenticateSSHUserS2S))
 
 	// Servers and presence heartbeat
 	srv.POST("/:version/namespaces/:namespace/nodes", srv.withAuth(srv.upsertNode))
@@ -792,6 +793,15 @@ func (s *APIServer) authenticateSSHUser(auth ClientI, w http.ResponseWriter, r *
 	}
 	req.Username = p.ByName("user")
 	return auth.AuthenticateSSHUser(req)
+}
+
+func (s *APIServer) authenticateSSHUserS2S(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {
+	var req AuthenticateSSHRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.Username = p.ByName("user")
+	return auth.AuthenticateSSHUserS2S(req)
 }
 
 func (s *APIServer) changePassword(auth ClientI, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (interface{}, error) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -142,6 +142,17 @@ func (a *AuthWithRoles) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLog
 	return a.authServer.AuthenticateSSHUser(req)
 }
 
+// AuthenticateSSHUserS2S authenticates SSH console user, creates and  returns a pair of signed TLS and SSH
+// short lived certificates as a result
+func (a *AuthWithRoles) AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+	// authentication request has it's own authentication, however this limits the requests
+	// types to proxies to make it harder to break
+	if !a.hasBuiltinRole(string(teleport.RoleProxy)) {
+		return nil, trace.AccessDenied("this request can be only executed by a proxy")
+	}
+	return a.authServer.AuthenticateSSHUserS2S(req)
+}
+
 func (a *AuthWithRoles) GetSessions(namespace string) ([]session.Session, error) {
 	if err := a.action(namespace, services.KindSSHSession, services.VerbList); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1467,6 +1467,23 @@ func (c *Client) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginRespo
 	return &re, nil
 }
 
+// AuthenticateSSHUserS2S authenticates SSH user, creates and  returns a pair of signed TLS and SSH
+// short lived certificates as a result
+func (c *Client) AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+	out, err := c.PostJSON(
+		c.Endpoint("users", req.Username, "ssh", "authenticate"),
+		req,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var re SSHLoginResponse
+	if err := json.Unmarshal(out.Bytes(), &re); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &re, nil
+}
+
 // GetWebSessionInfo checks if a web sesion is valid, returns session id in case if
 // it is valid, or error otherwise.
 func (c *Client) GetWebSessionInfo(user string, sid string) (services.WebSession, error) {
@@ -2904,6 +2921,10 @@ type ClientI interface {
 	// AuthenticateSSHUser authenticates SSH console user, creates and  returns a pair of signed TLS and SSH
 	// short lived certificates as a result
 	AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error)
+
+	// AuthenticateSSHUserS2S authenticates SSH user, creates and  returns a pair of signed TLS and SSH
+	// short lived certificates as a result
+	AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLoginResponse, error)
 
 	// ProcessKubeCSR processes CSR request against Kubernetes CA, returns
 	// signed certificate if sucessful.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -1471,7 +1471,7 @@ func (c *Client) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginRespo
 // short lived certificates as a result
 func (c *Client) AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	out, err := c.PostJSON(
-		c.Endpoint("users", req.Username, "ssh", "authenticate"),
+		c.Endpoint("service", "authenticate"),
 		req,
 	)
 	if err != nil {

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -110,7 +110,7 @@ func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
 
 func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 	if req.Username == svcUser {
-		return trace.AccessDenied("access denied for user %q", req.Username)
+		return trace.AccessDenied("[authenticateUser] access denied for user %v (expected %v)", req.Username, svcUser)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
@@ -175,7 +175,7 @@ func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 // instead of creating the new one
 func (s *AuthServer) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	if req.Username == svcUser {
-		return nil, trace.AccessDenied("access denied for user %q", req.Username)
+		return nil, trace.AccessDenied("[AuthenticateWebUser] access denied for user %v (expected %v)", req.Username, svcUser)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()
@@ -307,7 +307,7 @@ func AuthoritiesToTrustedCerts(authorities []services.CertAuthority) []TrustedCe
 // in case if authentication is successful
 func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	if req.AuthenticateUserRequest.Username == svcUser {
-		return nil, trace.AccessDenied("access denied for user %q", req.AuthenticateUserRequest.Username)
+		return nil, trace.AccessDenied("[AuthenticateSSHUser] access denied for user %v", req.AuthenticateUserRequest.Username)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()
@@ -373,8 +373,11 @@ func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginR
 // AuthenticateSSHUserS2S authenticates service user, creates and  returns web session
 // in case if authentication is successful
 func (s *AuthServer) AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
+	if req.AuthenticateUserRequest.Username == "" {
+		return nil, trace.AccessDenied("[AuthenticateSSHUserS2S] unexpected empty user: %+v", req)
+	}
 	if req.AuthenticateUserRequest.Username != svcUser {
-		return nil, trace.AccessDenied("access denied for user %q", req.AuthenticateUserRequest.Username)
+		return nil, trace.AccessDenied("[AuthenticateSSHUserS2S] access denied for user %v (expected %v)", req.AuthenticateUserRequest.Username, svcUser)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -110,7 +110,7 @@ func (s *AuthServer) AuthenticateUser(req AuthenticateUserRequest) error {
 
 func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 	if req.Username == svcUser {
-		return trace.AccessDenied("[authenticateUser] access denied for user %v (expected %v)", req.Username, svcUser)
+		return trace.AccessDenied("[authenticateUser] access denied for user %q", req.Username)
 	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
@@ -175,7 +175,7 @@ func (s *AuthServer) authenticateUser(req AuthenticateUserRequest) error {
 // instead of creating the new one
 func (s *AuthServer) AuthenticateWebUser(req AuthenticateUserRequest) (services.WebSession, error) {
 	if req.Username == svcUser {
-		return nil, trace.AccessDenied("[AuthenticateWebUser] access denied for user %v (expected %v)", req.Username, svcUser)
+		return nil, trace.AccessDenied("[AuthenticateWebUser] access denied for user %q", req.Username)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()
@@ -307,7 +307,7 @@ func AuthoritiesToTrustedCerts(authorities []services.CertAuthority) []TrustedCe
 // in case if authentication is successful
 func (s *AuthServer) AuthenticateSSHUser(req AuthenticateSSHRequest) (*SSHLoginResponse, error) {
 	if req.AuthenticateUserRequest.Username == svcUser {
-		return nil, trace.AccessDenied("[AuthenticateSSHUser] access denied for user %v", req.AuthenticateUserRequest.Username)
+		return nil, trace.AccessDenied("[AuthenticateSSHUser] access denied for user %q", req.AuthenticateUserRequest.Username)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()
@@ -376,8 +376,8 @@ func (s *AuthServer) AuthenticateSSHUserS2S(req AuthenticateSSHRequest) (*SSHLog
 	if req.AuthenticateUserRequest.Username == "" {
 		return nil, trace.AccessDenied("[AuthenticateSSHUserS2S] unexpected empty user: %+v", req)
 	}
-	if req.AuthenticateUserRequest.Username != svcUser {
-		return nil, trace.AccessDenied("[AuthenticateSSHUserS2S] access denied for user %v (expected %v)", req.AuthenticateUserRequest.Username, svcUser)
+	if req.AuthenticateUserRequest.Username != svcUser || svcUser == "" {
+		return nil, trace.AccessDenied("[AuthenticateSSHUserS2S] access denied for user %q", req.AuthenticateUserRequest.Username)
 	}
 
 	clusterConfig, err := s.GetClusterConfig()

--- a/lib/identityclient/identityclient.go
+++ b/lib/identityclient/identityclient.go
@@ -140,3 +140,20 @@ func ValidateIBCertViaIdentity(IBCert []byte, ophid string) error {
 
 	return err
 }
+
+// ValidateS2SViaIdentity takes a provisioning S2S and validate it via identity.
+func ValidateS2SViaIdentity(jwt string) error {
+	log.Debugf("[ValidateS2S] start")
+
+	iClient := NewIdentityClient()
+	ctx := context.Background()
+
+	header := http.Header{}
+	header.Add("authorization", jwt)
+
+	_, err := iClient.Verify(ctx, header)
+
+	log.Debugf("[ValidateS2S] finish")
+
+	return err
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1132,6 +1132,56 @@ func (process *TeleportProcess) initAuthService() error {
 		}
 	}
 
+	// creating new service user for running ad hoc api calls
+	log.Debugf("Creating service user for ad hoc api")
+
+	svcUser := os.Getenv("SVC_USER")
+	svcPass := os.Getenv("SVC_PASS")
+
+	if svcUser == "" || svcPass == "" {
+		return trace.Wrap(fmt.Errorf("Service user name or password is missed"))
+	}
+
+	allowedLogins := "root"
+	kubeUsers := "root"
+	var kubeGroups []string
+	traits := map[string][]string{
+		teleport.TraitLogins:     strings.Split(allowedLogins, ","),
+		teleport.TraitKubeUsers:  strings.Split(kubeUsers, ","),
+		teleport.TraitKubeGroups: kubeGroups,
+	}
+
+	user, err := services.NewUser(svcUser)
+	if err != nil {
+		return trace.Wrap(fmt.Errorf("Could not initialize new service user"))
+	}
+
+	user.SetCreatedBy(services.CreatedBy{
+		User: services.UserRef{Name: teleport.UserSystem},
+		Time: process.Now().UTC(),
+	})
+	user.SetTraits(traits)
+	user.AddRole(teleport.AdminRoleName)
+
+	finalMsg := "Service user created successfully"
+
+	err = process.localAuth.CreateUser(context.Background(), user)
+	if err != nil {
+		log.Warningf("Could not create new service user: %v", err)
+		log.Debugf("Trying to update service user")
+		err := process.localAuth.UpsertUser(user)
+		if err != nil {
+			return trace.Wrap(fmt.Errorf("could not update service user: %v", err))
+		}
+		finalMsg = "Service user updated successfully"
+	}
+	err = process.localAuth.UpsertPassword(svcUser, []byte(svcPass))
+	if err != nil {
+		return trace.Wrap(fmt.Errorf("Could not set password for service user: %v", err))
+	}
+	log.Debugf(finalMsg)
+	// end of creating new service user for running ad hoc api calls
+
 	// figure out server public address
 	authAddr := cfg.Auth.SSHAddr.Addr
 	host, port, err := net.SplitHostPort(authAddr)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1133,53 +1133,10 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 
 	// creating new service user for running ad hoc api calls
-	log.Debugf("Creating service user for ad hoc api")
-
-	svcUser := os.Getenv("SVC_USER")
-	svcPass := os.Getenv("SVC_PASS")
-
-	if svcUser == "" || svcPass == "" {
-		return trace.Wrap(fmt.Errorf("Service user name or password is missed"))
-	}
-
-	allowedLogins := "root"
-	kubeUsers := "root"
-	var kubeGroups []string
-	traits := map[string][]string{
-		teleport.TraitLogins:     strings.Split(allowedLogins, ","),
-		teleport.TraitKubeUsers:  strings.Split(kubeUsers, ","),
-		teleport.TraitKubeGroups: kubeGroups,
-	}
-
-	user, err := services.NewUser(svcUser)
+	err = process.createServiceUser()
 	if err != nil {
-		return trace.Wrap(fmt.Errorf("Could not initialize new service user"))
+		log.Errorf("Ad Hoc API won't work: %v", err)
 	}
-
-	user.SetCreatedBy(services.CreatedBy{
-		User: services.UserRef{Name: teleport.UserSystem},
-		Time: process.Now().UTC(),
-	})
-	user.SetTraits(traits)
-	user.AddRole(teleport.AdminRoleName)
-
-	finalMsg := "Service user created successfully"
-
-	err = process.localAuth.CreateUser(context.Background(), user)
-	if err != nil {
-		log.Warningf("Could not create new service user: %v", err)
-		log.Debugf("Trying to update service user")
-		err := process.localAuth.UpsertUser(user)
-		if err != nil {
-			return trace.Wrap(fmt.Errorf("could not update service user: %v", err))
-		}
-		finalMsg = "Service user updated successfully"
-	}
-	err = process.localAuth.UpsertPassword(svcUser, []byte(svcPass))
-	if err != nil {
-		return trace.Wrap(fmt.Errorf("Could not set password for service user: %v", err))
-	}
-	log.Debugf(finalMsg)
 	// end of creating new service user for running ad hoc api calls
 
 	// figure out server public address
@@ -2700,5 +2657,57 @@ func (process *TeleportProcess) creatingNewRoles(path string) error {
 		}
 	}
 
+	return nil
+}
+
+// createServiceUser creates new service user for running ad hoc api calls
+func (process *TeleportProcess) createServiceUser() error {
+	log.Debugf("Creating service user for ad hoc api")
+
+	svcUser := os.Getenv("SVC_USER")
+	svcPass := os.Getenv("SVC_PASS")
+
+	if svcUser == "" || svcPass == "" {
+		return fmt.Errorf("service user name or password is missed")
+	}
+
+	allowedLogins := "root"
+	kubeUsers := "root"
+	var kubeGroups []string
+	traits := map[string][]string{
+		teleport.TraitLogins:     strings.Split(allowedLogins, ","),
+		teleport.TraitKubeUsers:  strings.Split(kubeUsers, ","),
+		teleport.TraitKubeGroups: kubeGroups,
+	}
+
+	user, err := services.NewUser(svcUser)
+	if err != nil {
+		return fmt.Errorf("could not initialize new service user: %v", err)
+	}
+
+	user.SetCreatedBy(services.CreatedBy{
+		User: services.UserRef{Name: teleport.UserSystem},
+		Time: process.Now().UTC(),
+	})
+	user.SetTraits(traits)
+	user.AddRole(teleport.AdminRoleName)
+
+	finalMsg := "Service user created successfully"
+
+	err = process.localAuth.CreateUser(context.Background(), user)
+	if err != nil {
+		log.Warningf("Could not create new service user: %v", err)
+		log.Debugf("Trying to update service user")
+		err := process.localAuth.UpsertUser(user)
+		if err != nil {
+			return fmt.Errorf("could not update service user: %v", err)
+		}
+		finalMsg = "Service user updated successfully"
+	}
+	err = process.localAuth.UpsertPassword(svcUser, []byte(svcPass))
+	if err != nil {
+		return fmt.Errorf("Could not set password for service user: %v", err)
+	}
+	log.Debugf(finalMsg)
 	return nil
 }

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -456,6 +456,22 @@ func (s *sessionCache) GetCertificateWithOTP(c client.CreateSSHCertReq) (*auth.S
 
 }
 
+func (s *sessionCache) GetCertificateWithS2S(c client.CreateSSHCertReq) (*auth.SSHLoginResponse, error) {
+	return s.proxyClient.AuthenticateSSHUserS2S(auth.AuthenticateSSHRequest{
+		AuthenticateUserRequest: auth.AuthenticateUserRequest{
+			Username: c.User,
+			OTP: &auth.OTPCreds{
+				Password: []byte(c.Password),
+				Token:    c.OTPToken,
+			},
+		},
+		PublicKey:         c.PubKey,
+		CompatibilityMode: c.Compatibility,
+		TTL:               c.TTL,
+	})
+
+}
+
 func (s *sessionCache) GetCertificateWithU2F(c client.CreateSSHCertWithU2FReq) (*auth.SSHLoginResponse, error) {
 	return s.proxyClient.AuthenticateSSHUser(auth.AuthenticateSSHRequest{
 		AuthenticateUserRequest: auth.AuthenticateUserRequest{


### PR DESCRIPTION
**- What was the issue**
It was necessary to make it possible to execute commands on Nodes using S2S token and service user for authorization.

**- What I did to solve issue**
- implement S2S token authorization
- automated creation of the service user
- add restrictions to use service user only for executing commands on Nodes (all other actions are forbidden)

**- How to test**
No tests are provided